### PR TITLE
Fix video queue list rendering

### DIFF
--- a/fabric/src/main/java/com/cinemamod/fabric/block/PreviewScreenBlockEntity.java
+++ b/fabric/src/main/java/com/cinemamod/fabric/block/PreviewScreenBlockEntity.java
@@ -4,6 +4,8 @@ import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityT
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 
@@ -25,6 +27,7 @@ public class PreviewScreenBlockEntity extends BlockEntity {
         PREVIEW_SCREEN_BLOCK_ENTITY = FabricBlockEntityTypeBuilder
                 .create(PreviewScreenBlockEntity::new, PreviewScreenBlock.PREVIEW_SCREEN_BLOCK)
                 .build();
+        Registry.register(Registries.BLOCK_ENTITY_TYPE, IDENT, PREVIEW_SCREEN_BLOCK_ENTITY);
     }
 
 }

--- a/fabric/src/main/java/com/cinemamod/fabric/block/ScreenBlockEntity.java
+++ b/fabric/src/main/java/com/cinemamod/fabric/block/ScreenBlockEntity.java
@@ -4,6 +4,8 @@ import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityT
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 
@@ -25,6 +27,7 @@ public class ScreenBlockEntity extends BlockEntity {
         SCREEN_BLOCK_ENTITY = FabricBlockEntityTypeBuilder
                 .create(ScreenBlockEntity::new, ScreenBlock.SCREEN_BLOCK)
                 .build();
+        Registry.register(Registries.BLOCK_ENTITY_TYPE, IDENT, SCREEN_BLOCK_ENTITY);
     }
 
 }

--- a/fabric/src/main/java/com/cinemamod/fabric/gui/widget/VideoListWidget.java
+++ b/fabric/src/main/java/com/cinemamod/fabric/gui/widget/VideoListWidget.java
@@ -26,8 +26,7 @@ public abstract class VideoListWidget extends ElementListWidget<VideoListWidgetE
 
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        double d = client.getWindow().getScaleFactor();
-        context.enableScissor((int) ((double) this.getRowLeft() * d), (int) ((double) (this.height - this.bottom) * d), (int) ((double) (this.getScrollbarPositionX() + 6) * d), (int) ((double) (this.height - (this.height - this.bottom) - this.top - 4) * d));
+        context.enableScissor(this.getRowLeft(), this.top + 4, this.getScrollbarPositionX() + this.getRowLeft() + 6, this.height - this.top - 4);
         super.render(context, mouseX, mouseY, delta);
         context.disableScissor();
     }

--- a/fabric/src/main/java/com/cinemamod/fabric/gui/widget/VideoQueueWidget.java
+++ b/fabric/src/main/java/com/cinemamod/fabric/gui/widget/VideoQueueWidget.java
@@ -25,8 +25,7 @@ public class VideoQueueWidget extends ElementListWidget<VideoQueueWidgetEntry> {
 
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        double d = client.getWindow().getScaleFactor();
-        context.enableScissor((int) ((double) this.getRowLeft() * d), (int) ((double) (this.height - this.bottom) * d), (int) ((double) (this.getScrollbarPositionX() + 6) * d), (int) ((double) (this.height - (this.height - this.bottom) - this.top - 4) * d));
+        context.enableScissor(this.getRowLeft(), this.top + 4, this.getScrollbarPositionX() + this.getRowLeft() + 6, this.height - this.top - 4);
         super.render(context, mouseX, mouseY, delta);
         context.disableScissor();
     }


### PR DESCRIPTION
I totally overlooked this. The enableScissor in DrawContext has different parameters than the RenderSystem had (x1, y1, x2, y2 instead of x, y, width, height). Also no need to scale anymore because it does that internally.
There are still some issues:
- scrollbar is overlapping delete buttons (this was also present in previous versions)
- tooltip is cut off on the left of the list