### PR TITLE
[bukkit] universalize URL Parsing method

### DIFF
--- a/bukkit/src/main/java/com/cinemamod/bukkit/service/VideoURLParser.java
+++ b/bukkit/src/main/java/com/cinemamod/bukkit/service/VideoURLParser.java
@@ -42,7 +42,7 @@ public class VideoURLParser {
             infoFetcher = new TwitchVideoInfoFetcher(twitchUser);
             return;
         }
-        String hlsLink = getLink(url, "\\.(m3u(8|))(?=\\??)", 0);
+        String hlsLink = getLink(url, "^https?:\\/\\/[\\w\\-]+(\\.[\\w\\-]+)*\\/[\\w\\-]+\\.(m3u8?)(\\?.*)?$", 0);
         if (hlsLink != null) {
             infoFetcher = new HLSVideoInfoFetcher(url, player == null ? "server" : player.getName());
             return;


### PR DESCRIPTION
this applies a regex logic to not just youtube links but also regular video/audio files and hls streams, which allows those to function even when there are additional url parameters such as obligatory inline tokens and whatnot.

i had yet to actually try this ingame, so tests and reviews are welcome.