### PR TITLE
[bukkit] attempt 2 at universalizing URL Parsing methods

### DIFF
--- a/bukkit/src/main/java/com/cinemamod/bukkit/service/VideoURLParser.java
+++ b/bukkit/src/main/java/com/cinemamod/bukkit/service/VideoURLParser.java
@@ -3,6 +3,8 @@ package com.cinemamod.bukkit.service;
 import com.cinemamod.bukkit.CinemaModPlugin;
 import com.cinemamod.bukkit.service.infofetcher.*;
 import org.bukkit.entity.Player;
+import java.net.URL;
+import java.io.IOException;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -42,13 +44,13 @@ public class VideoURLParser {
             infoFetcher = new TwitchVideoInfoFetcher(twitchUser);
             return;
         }
-        String hlsLink = getLink(url, "^https?:\\/\\/[\\w\\-]+(\\.[\\w\\-]+)*\\/[\\w\\-]+\\.(m3u8?)(\\?.*)?$", 0);
+        String hlsLink = getLink(url, "^https?:\\/\\/[\\S\\-]+(\\.[\\S\\-]+)*\\/[\\S\\-]+\\.(m3u8)(.*)?$", 0);
         if (hlsLink != null) {
             infoFetcher = new HLSVideoInfoFetcher(url, player == null ? "server" : player.getName());
             return;
         }
 
-        String mediaLink = getLink(url, "^https?:\\/\\/[\\w\\-]+(\\.[\\w\\-]+)*\\/[\\w\\-]+\\.((mp[3-4]|opus|m4v|webm|ogg))(\\?.*)?$", 0);
+        String mediaLink = getLink(url, "^https?:\\/\\/[\\W\\w\\-]+(\\.[\\W\\w\\-]+)*\\/[\\W\\w\\-]+\\.(mp[3-4]|ts|ogg|opus|webm|m4v)(.*)?$", 0);
         if (mediaLink != null) {
             infoFetcher = new FileVideoInfoFetcher("cinemamod.request.file", url, player == null ? "server" : player.getName());
             return;
@@ -57,9 +59,25 @@ public class VideoURLParser {
     }
     private static String getLink(String url, String regex, int group) {
         String link = null;
-        Pattern ptn = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
-        Matcher matcher = ptn.matcher(url);
-        if (matcher.find()) { link = matcher.group(group); }
+        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(url);
+        if (matcher.find()) { 
+            if (group != 0) {
+                link = matcher.group(group); 
+            }
+            else {
+                Pattern mimePattern = Pattern.compile(
+                    "(video|audio|application)\\/(mp4|mp3|opus|mp2t|wav|webm|mkv|mpegurl|vnd.apple.mpegurl)", 
+                    Pattern.CASE_INSENSITIVE);
+                try {
+                    String contentTypeResponse = new URL(url).openConnection().getContentType();
+                    Matcher mimeMatcher = mimePattern.matcher(contentTypeResponse);
+                    if (mimeMatcher.find()) {
+                        link = matcher.group(group); 
+                    }
+                } catch (IOException ignored) {}
+            }
+        }
         return link;
     }
     public VideoInfoFetcher getInfoFetcher() {


### PR DESCRIPTION
here we go again---

this uses both regex verification and \*also\* verifies if the url contains a valid mimetype prior to adding to the queue.

tested to be working at local builds.